### PR TITLE
Updates to enable us to use this with existing providers and handle mutating the repo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ We recommend using GitHub's OIDC provider to get short-lived credentials needed 
 ## Features
 
 1. Create an AWS OIDC provider for GitHub Actions
-1. Create one or more IAM role that can be assumed by GitHub Actions
-1. IAM roles can be scoped to :
+2. Create one or more IAM role that can be assumed by GitHub Actions
+3. IAM roles can be scoped to :
      * One or more GitHub organisations
      * One or more GitHub repository
      * One or more branches in a repository
-1. Use existing OIDC provider and roles with Terraform
+4. Use existing OIDC provider and roles with Terraform
      * Reference an existing OIDC provider by ARN
      * Reference an existing IAM role by ARN
      * Optionally attach policies to existing roles

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,50 @@
  * This module allows you to create a Github OIDC provider for your AWS account, that will help Github Actions to securely authenticate against the AWS API using an IAM role
  *
 */
+
+locals {
+  # ------------------------------------------------------------
+  # Input validation for required inputs
+  # ------------------------------------------------------------
+
+  # Check that oidc_provider_arn is provided when create_oidc_provider is false
+  validate_oidc_provider = (var.create_oidc_provider || var.oidc_provider_arn != null) ? true : tobool(
+    "When create_oidc_provider is false, oidc_provider_arn must be provided"
+  )
+  
+  # Check that oidc_role_arn is provided when create_oidc_role is false
+  validate_oidc_role = (var.create_oidc_role || var.oidc_role_arn != null) ? true : tobool(
+    "When create_oidc_role is false, oidc_role_arn must be provided"
+  )
+
+  # validate the github_thumbprint is provided if create_oidc_provider is true
+  validate_github_thumbprint = (var.create_oidc_provider && var.github_thumbprint != null) ? true : tobool(
+    "When create_oidc_provider is true, github_thumbprint must be provided"
+  )
+
+  # ------------------------------------------------------------
+  # Inputs
+  # ------------------------------------------------------------
+
+  # Determine the provider ARN to use - either created by this module or externally provided
+  oidc_provider_arn = var.create_oidc_provider ? aws_iam_openid_connect_provider.this[0].arn : var.oidc_provider_arn
+  
+  # Determine the role ARN to use - either created by this module or externally provided
+  role_arn = var.create_oidc_role ? aws_iam_role.this[0].arn : var.oidc_role_arn
+  
+  # Extract role name from ARN for policy attachments when using existing role
+  existing_role_name = var.create_oidc_role ? null : element(split("/", var.oidc_role_arn), length(split("/", var.oidc_role_arn)) - 1)
+  
+  # For role name, use either the created role or the extracted name from ARN
+  role_name = var.create_oidc_role ? aws_iam_role.this[0].name : local.existing_role_name
+  
+  # Determine whether to attach policies (when creating a role or explicitly requested for existing role)
+  attach_policies = var.create_oidc_role || var.attach_policies_to_existing_role
+  
+  # Determine whether to update the assume role policy for an existing role
+  update_role_policy = !var.create_oidc_role && var.update_existing_role_policy
+}
+
 resource "aws_iam_openid_connect_provider" "this" {
   count = var.create_oidc_provider ? 1 : 0
   client_id_list = [
@@ -19,25 +63,45 @@ resource "aws_iam_role" "this" {
   name                 = var.role_name
   description          = var.role_description
   max_session_duration = var.max_session_duration
-  assume_role_policy   = join("", data.aws_iam_policy_document.this[0].*.json)
+  assume_role_policy   = data.aws_iam_policy_document.this.json
   tags                 = var.tags
-  # path                  = var.iam_role_path
-  # permissions_boundary  = var.iam_role_permissions_boundary
+  path                 = var.iam_role_path
+  permissions_boundary = var.iam_role_permissions_boundary
   depends_on = [aws_iam_openid_connect_provider.this]
 }
 
+# Update assume role policy for existing roles
+resource "aws_iam_role" "update_assume_role_policy" {
+  count = local.update_role_policy ? 1 : 0
+  
+  name                 = local.role_name
+  assume_role_policy   = data.aws_iam_policy_document.this.json
+  
+  # Preserve existing role settings
+  lifecycle {
+    ignore_changes = [
+      description,
+      max_session_duration,
+      permissions_boundary,
+      tags,
+      path,
+      force_detach_policies,
+      managed_policy_arns
+    ]
+  }
+}
+
 resource "aws_iam_role_policy_attachment" "attach" {
-  count = var.create_oidc_role ? length(var.oidc_role_attach_policies) : 0
+  count = local.attach_policies ? length(var.oidc_role_attach_policies) : 0
 
   policy_arn = var.oidc_role_attach_policies[count.index]
-  role       = join("", aws_iam_role.this.*.name)
+  role       = local.role_name
 
   depends_on = [aws_iam_role.this]
 }
 
+# Create the policy document for all cases (new roles and for updating existing roles)
 data "aws_iam_policy_document" "this" {
-  count = var.create_oidc_role ? 1 : 0
-
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     effect  = "Allow"
@@ -52,7 +116,7 @@ data "aws_iam_policy_document" "this" {
     }
 
     principals {
-      identifiers = [try(aws_iam_openid_connect_provider.this[0].arn, var.oidc_provider_arn)]
+      identifiers = [local.oidc_provider_arn]
       type        = "Federated"
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,14 @@
 output "oidc_provider_arn" {
   description = "OIDC provider ARN"
-  value       = try(aws_iam_openid_connect_provider.this[0].arn, "")
+  value       = local.oidc_provider_arn
 }
 
-output "oidc_role" {
-  description = "CICD GitHub role."
-  value       = try(aws_iam_role.this[0].arn, "")
+output "oidc_role_arn" {
+  description = "CICD GitHub role ARN"
+  value       = local.role_arn
+}
+
+output "oidc_role_name" {
+  description = "CICD GitHub role name"
+  value       = local.role_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,36 @@ variable "create_oidc_role" {
   default     = true
 }
 
+variable "oidc_role_arn" {
+  description = "ARN of the OIDC role to use. Required if 'create_oidc_role' is false"
+  type        = string
+  default     = null
+}
+
+variable "attach_policies_to_existing_role" {
+  description = "Whether to attach the specified policies to an existing role when 'create_oidc_role' is false"
+  type        = bool
+  default     = false
+}
+
+variable "update_existing_role_policy" {
+  description = "Whether to update the assume role policy of an existing role with the repository list from 'repositories' variable"
+  type        = bool
+  default     = false
+}
+
+variable "iam_role_path" {
+  description = "Path for the IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "iam_role_permissions_boundary" {
+  description = "ARN of the permissions boundary to use for the IAM role"
+  type        = string
+  default     = null
+}
+
 # Refer to the README for information on obtaining the thumbprint.
 # This is specified as a variable to allow it to be updated quickly if it is
 # unexpectedly changed by GitHub.


### PR DESCRIPTION
Forked the public repo into ours, when we get this working will do a PR into the main on to give it back. That said, this is to add the following features to that module:

4. Use existing OIDC provider and roles with Terraform
     * Reference an existing OIDC provider by ARN
     * Reference an existing IAM role by ARN
     * Optionally attach policies to existing roles
     * Update repository access list for existing roles