### PR TITLE
Attempt 1: Updating to handle create or use existing properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ No modules.
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_role.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -7,50 +7,43 @@
 */
 
 locals {
-  # ------------------------------------------------------------
-  # Input validation for required inputs
-  # ------------------------------------------------------------
-
-  # Check that oidc_provider_arn is provided when create_oidc_provider is false
+  # validations
   validate_oidc_provider = var.create_oidc_provider || var.oidc_provider_arn != null
+  validate_oidc_role     = var.create_oidc_role || var.oidc_role_arn != null
 
-  # Check that oidc_role_arn is provided when create_oidc_role is false
-  validate_oidc_role = var.create_oidc_role || var.oidc_role_arn != null
+  # toggles
+  attach_policies    = var.create_oidc_role || var.attach_policies_to_existing_role
+  update_role_policy = !var.create_oidc_role && var.update_existing_role_policy
 
-  # ------------------------------------------------------------
-  # Inputs
-  # ------------------------------------------------------------
+  # pick the created ARN or fall back to external
+  oidc_provider_arn = try(
+    aws_iam_openid_connect_provider.this["oidc"].arn,
+    var.oidc_provider_arn,
+  )
 
-  # Determine the provider ARN to use - either created by this module or externally provided
-  oidc_provider_arn = var.create_oidc_provider ? aws_iam_openid_connect_provider.this[0].arn : var.oidc_provider_arn
-
-  # Determine the role ARN to use - either created by this module or externally provided
-  role_arn = var.create_oidc_role ? aws_iam_role.this[0].arn : var.oidc_role_arn
+  role_arn = try(
+    aws_iam_role.this["role"].arn,
+    var.oidc_role_arn,
+  )
 
   # Extract role name from ARN for policy attachments when using existing role
   existing_role_name = (var.create_oidc_role || var.oidc_role_arn == null) ? null : element(split("/", var.oidc_role_arn), length(split("/", var.oidc_role_arn)) - 1)
 
   # For role name, use either the created role or the extracted name from ARN
   role_name = var.create_oidc_role ? aws_iam_role.this[0].name : local.existing_role_name
-
-  # Determine whether to attach policies (when creating a role or explicitly requested for existing role)
-  attach_policies = var.create_oidc_role || var.attach_policies_to_existing_role
-
-  # Determine whether to update the assume role policy for an existing role
-  update_role_policy = !var.create_oidc_role && var.update_existing_role_policy
 }
 
 resource "aws_iam_openid_connect_provider" "this" {
-  count = var.create_oidc_provider ? 1 : 0
-  client_id_list = [
-    "sts.amazonaws.com",
-  ]
-  thumbprint_list = [var.github_thumbprint]
+  for_each = var.create_oidc_provider ? { oidc = true } : {}
+
   url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [var.github_thumbprint]
 }
 
 resource "aws_iam_role" "this" {
-  count                = var.create_oidc_role ? 1 : 0
+  for_each = var.create_oidc_role ? { role = true } : {}
+
   name                 = var.role_name
   description          = var.role_description
   max_session_duration = var.max_session_duration
@@ -58,27 +51,15 @@ resource "aws_iam_role" "this" {
   tags                 = var.tags
   path                 = var.iam_role_path
   permissions_boundary = var.iam_role_permissions_boundary
-  depends_on           = [aws_iam_openid_connect_provider.this]
-}
 
-# Data source for existing role - used for validation and name resolution
-data "aws_iam_role" "existing" {
-  count = (!var.create_oidc_role && (var.update_existing_role_policy || var.attach_policies_to_existing_role)) ? 1 : 0
-  name  = var.role_name
-
-  # Add lifecycle to prevent terraform from failing if role doesn't exist during refresh
-  lifecycle {
-    postcondition {
-      condition     = self.arn != null
-      error_message = "The specified role ${var.role_name} does not exist"
-    }
-  }
+  depends_on = [aws_iam_openid_connect_provider.this]
 }
 
 # Update assume role policy for existing roles
 resource "aws_iam_role" "existing_role_policy" {
-  count              = local.update_role_policy ? 1 : 0
-  name               = data.aws_iam_role.existing[0].name
+  for_each = local.update_role_policy ? { (var.role_name) = var.role_name } : {}
+
+  name               = each.key
   assume_role_policy = data.aws_iam_policy_document.this.json
 
   lifecycle {
@@ -95,13 +76,12 @@ resource "aws_iam_role" "existing_role_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach" {
-  count = local.attach_policies ? length(var.oidc_role_attach_policies) : 0
+  for_each = local.attach_policies ? toset(var.oidc_role_attach_policies) : toset([])
 
-  policy_arn = var.oidc_role_attach_policies[count.index]
-  # Use the validated role name from the data source when attaching to existing role
-  role = var.create_oidc_role ? aws_iam_role.this[0].name : data.aws_iam_role.existing[0].name
+  policy_arn = each.value
+  role       = local.role_name
 
-  depends_on = [aws_iam_role.this, data.aws_iam_role.existing]
+  depends_on = [aws_iam_role.this]
 }
 
 # Create the policy document for all cases (new roles and for updating existing roles)

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ locals {
   existing_role_name = (var.create_oidc_role || var.oidc_role_arn == null) ? null : element(split("/", var.oidc_role_arn), length(split("/", var.oidc_role_arn)) - 1)
 
   # For role name, use either the created role or the extracted name from ARN
-  role_name = var.create_oidc_role ? aws_iam_role.this[0].name : local.existing_role_name
+  role_name = var.create_oidc_role ? aws_iam_role.this["role"].name : local.existing_role_name
 }
 
 resource "aws_iam_openid_connect_provider" "this" {


### PR DESCRIPTION
**Overview**
This PR refactors the module logic to robustly support both creation of new AWS OIDC providers and IAM roles, as well as the use of existing resources, based on input variables. The changes ensure that Terraform will not attempt to create or reference resources unnecessarily, and will fail early with clear error messages if required inputs are missing.

**Key Changes**
_Conditional Resource Creation:_
OIDC provider and IAM role resources are only created if their respective create_* variables are set to true.
When not creating, the module expects ARNs for existing resources to be provided.

_Safe Referencing of ARNs:_
Uses try() to safely reference ARNs from either created or provided resources, preventing apply-time errors.

_Role Name Extraction:_
When using an existing IAM role, the role name is extracted from the provided ARN for use in policy attachments and updates.

_Policy Attachment and Updates:_
Policies are attached to the correct role (created or existing) based on toggles.
Supports updating the assume role policy for existing roles without managing other properties, using ignore_changes.

_Validation Checks:_
Early validation ensures that required variables are set, and that session duration is within AWS limits.
Clear error messages are provided for missing or invalid configuration.

**Benefits**

_Prevents Apply-Time Errors:_
The module will not attempt to create or reference resources that are not needed, avoiding common Terraform errors when toggling between creation and usage of existing resources.

_Clear User Feedback:_
Early validation checks provide immediate and actionable feedback if the configuration is incomplete or invalid.

_Flexible Usage:_
Supports all combinations of creating new or using existing OIDC providers and IAM roles, as well as updating policies on existing roles.

**How to Use**

- To create new resources, set create_oidc_provider and/or create_oidc_role to true.
- To use existing resources, set the above to false and provide the corresponding ARNs.
- To attach policies to an existing role, set attach_policies_to_existing_role to true.
- To update the assume role policy on an existing role, set update_existing_role_policy to true.